### PR TITLE
Make macOS a first-class, working platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,26 @@ jobs:
       - name: Build macOS app bundle
         run: cargo bundle --release
 
+      - name: Inject Info.plist permissions
+        shell: bash
+        run: |
+          PLIST="target/release/bundle/osx/Duper Disper.app/Contents/Info.plist"
+          plist_set() {  # $1=entry  $2=type  $3=value
+            /usr/libexec/PlistBuddy -c "Add ${1} ${2} ${3}" "${PLIST}" 2>/dev/null || true
+            /usr/libexec/PlistBuddy -c "Set ${1} ${3}" "${PLIST}"
+          }
+          # Required: without a microphone usage string macOS terminates the app
+          # the moment it touches the mic.
+          plist_set ":NSMicrophoneUsageDescription" string \
+            "Duper Disper needs the microphone for push-to-talk dictation."
+          # Used when reading the active app/window for refinement context.
+          plist_set ":NSAppleEventsUsageDescription" string \
+            "Duper Disper reads the active app and window to improve transcription."
+          # Run as a menu-bar agent (no Dock icon).
+          plist_set ":LSUIElement" bool true
+          echo "----- Final Info.plist -----"
+          /usr/libexec/PlistBuddy -c "Print" "${PLIST}"
+
       - name: Package app bundle
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,6 +1267,9 @@ dependencies = [
  "eframe",
  "enigo",
  "hound",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "rdev",
  "reqwest",
  "screenshots",
@@ -3315,10 +3318,10 @@ dependencies = [
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
 ]
 
 [[package]]
@@ -3328,10 +3331,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -3345,6 +3356,17 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3368,6 +3390,17 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3407,6 +3440,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-core-location"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,6 +3459,31 @@ dependencies = [
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -3445,6 +3513,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
  "objc2-core-foundation",
 ]
@@ -3498,6 +3567,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-symbols"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3516,13 +3596,13 @@ dependencies = [
  "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,14 @@ version = "0.2.0"
 edition = "2021"
 description = "Fast push-to-talk voice transcription and refinement tool"
 
+# The binary is a GUI tray app and needs all three default features. Declaring
+# them as required-features means `cargo build --no-default-features` cleanly
+# skips the binary (and just builds the library) instead of failing to compile.
+[[bin]]
+name = "duper-disper"
+path = "src/main.rs"
+required-features = ["ui", "audio-capture", "local-stt"]
+
 [features]
 default = ["ui", "audio-capture", "local-stt"]
 ui = ["dep:tray-icon", "dep:eframe", "dep:winit"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ windows = { version = "0.58", features = [
     "Win32_System_ProcessStatus",
     "Win32_System_Threading",
     "Win32_System_Registry",
+    "Win32_System_Diagnostics_Debug",
     "Win32_Security",
 ] }
 screenshots = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,27 @@ windows = { version = "0.58", features = [
 ] }
 screenshots = "0.8"
 
+# macOS-specific APIs (menu-bar app lifecycle, AppKit event pump, active-window
+# context). Versions match those pulled in transitively by tray-icon 0.19 to
+# avoid duplicate objc2 trees. CoreFoundation/CoreGraphics/Accessibility are
+# accessed via direct C FFI in src/macos.rs (no extra crates needed).
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = [
+    "NSString",
+    "NSDate",
+    "NSRunLoop",
+    "NSThread",
+    "NSObjCRuntime",
+] }
+objc2-app-kit = { version = "0.3", features = [
+    "NSApplication",
+    "NSResponder",
+    "NSEvent",
+    "NSRunningApplication",
+    "NSWorkspace",
+] }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 wiremock = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,11 @@ windows = { version = "0.58", features = [
 screenshots = "0.8"
 
 # macOS-specific APIs (menu-bar app lifecycle, AppKit event pump, active-window
-# context). Versions match those pulled in transitively by tray-icon 0.19 to
-# avoid duplicate objc2 trees. CoreFoundation/CoreGraphics/Accessibility are
-# accessed via direct C FFI in src/macos.rs (no extra crates needed).
+# context). Pinned to the objc2 0.6 / objc2-*-0.3 family that tray-icon 0.19
+# already compiles, so we reuse those crates instead of adding another modern
+# objc2 copy. (Older objc2 0.5.x may still appear in the lockfile via unrelated
+# deps like cocoa/core-graphics; that's separate.) CoreFoundation /
+# CoreGraphics / Accessibility are accessed via direct C FFI in src/macos.rs.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = [

--- a/README.md
+++ b/README.md
@@ -6,8 +6,19 @@ A fast, native push-to-talk voice transcription tool built in Rust. Inspired by 
 
 Download the latest release from the [Releases page](https://github.com/sgstq/duper-disper/releases/latest):
 
+**Windows**
 - **Installer** — `duper-disper-x.x.x-setup.exe` — guided setup with Start Menu shortcut and uninstaller
 - **Portable** — `duper-disper-x.x.x-portable.zip` — standalone executable, no installation needed
+
+**macOS**
+- **App bundle** — `duper-disper-x.x.x-macos-app.zip` — unzip and drag `Duper Disper.app` to `/Applications`
+
+On macOS the app runs as a menu-bar (status-bar) app with no Dock icon. On first
+launch it will prompt for **Accessibility** permission (needed to detect the
+global hotkey and paste/type text) and **Microphone** permission (needed to
+record). Grant both in **System Settings → Privacy & Security**, then relaunch
+the app if the hotkey doesn't respond. The build is unsigned, so the first time
+you open it use **right-click → Open** to bypass Gatekeeper.
 
 ### Warning
 <p align="center">
@@ -22,7 +33,7 @@ Download the latest release from the [Releases page](https://github.com/sgstq/du
 - **Local-first** — Runs Whisper.cpp locally for transcription, no cloud required
 - **LLM refinement** — Optionally refines raw transcripts using an LLM (local via Ollama/LM Studio, or cloud APIs)
 - **Context-aware** — Captures active application name, window title, surrounding text, and optionally a screenshot to improve refinement quality
-- **System tray** — Runs quietly in the system tray with a minimal recording overlay
+- **System tray / menu bar** — Runs quietly in the tray (Windows) or menu bar (macOS); the icon turns red while recording, plus an optional sound cue and (on Windows) a floating overlay
 
 ## Architecture
 

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -178,8 +178,14 @@ pub fn resample(samples: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
         return samples.to_vec();
     }
 
+    if samples.is_empty() {
+        return Vec::new();
+    }
+
     let ratio = from_rate as f64 / to_rate as f64;
-    let output_len = (samples.len() as f64 / ratio) as usize;
+    // Round to the nearest sample count, and always produce at least one sample
+    // for non-empty input (a very short clip must not vanish on downsample).
+    let output_len = ((samples.len() as f64 / ratio).round() as usize).max(1);
     let mut output = Vec::with_capacity(output_len);
 
     for i in 0..output_len {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -199,9 +199,74 @@ impl AppConfig {
         unsafe { let _ = RegCloseKey(hkey); }
     }
 
-    #[cfg(not(windows))]
+    /// Sync the macOS LaunchAgent with the config value so the app can start
+    /// automatically when the user logs in.
+    #[cfg(target_os = "macos")]
     fn apply_auto_start(&self) {
-        // No-op on non-Windows platforms
+        let Some(home) = dirs::home_dir() else {
+            tracing::warn!("Cannot determine home dir for auto-start");
+            return;
+        };
+        let agents_dir = home.join("Library/LaunchAgents");
+        let plist_path = agents_dir.join("com.sgstq.duper-disper.plist");
+
+        if self.auto_start {
+            let exe = match std::env::current_exe() {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!("Failed to determine exe path for auto-start: {}", e);
+                    return;
+                }
+            };
+            if let Err(e) = std::fs::create_dir_all(&agents_dir) {
+                tracing::warn!("Failed to create LaunchAgents dir: {}", e);
+                return;
+            }
+            // Escape XML special characters in the executable path.
+            let exe_str = exe.to_string_lossy();
+            let exe_escaped = exe_str
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;");
+            let plist = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.sgstq.duper-disper</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{exe_escaped}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>
+"#
+            );
+            if let Err(e) = std::fs::write(&plist_path, plist) {
+                tracing::warn!("Failed to write LaunchAgent plist: {}", e);
+            } else {
+                info!("Auto-start LaunchAgent written to {:?}", plist_path);
+            }
+        } else if plist_path.exists() {
+            // Best-effort unload, then remove the plist.
+            let _ = std::process::Command::new("launchctl")
+                .arg("unload")
+                .arg(&plist_path)
+                .output();
+            if let Err(e) = std::fs::remove_file(&plist_path) {
+                tracing::debug!("Failed to remove LaunchAgent plist: {}", e);
+            }
+        }
+    }
+
+    #[cfg(all(not(windows), not(target_os = "macos")))]
+    fn apply_auto_start(&self) {
+        // No-op on other platforms
     }
 }
 

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -2,7 +2,7 @@
 use anyhow::Result;
 #[cfg(windows)]
 use tracing::debug;
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_os = "macos")))]
 use tracing::warn;
 
 /// The detected category of the active application.
@@ -205,13 +205,17 @@ pub fn capture_context(include_screenshot: bool) -> CapturedContext {
     {
         capture_context_windows(include_screenshot)
     }
-    #[cfg(not(windows))]
+    #[cfg(target_os = "macos")]
+    {
+        crate::macos::capture_context(include_screenshot)
+    }
+    #[cfg(all(not(windows), not(target_os = "macos")))]
     {
         capture_context_stub(include_screenshot)
     }
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_os = "macos")))]
 fn capture_context_stub(_include_screenshot: bool) -> CapturedContext {
     warn!("Context capture not implemented for this platform");
     CapturedContext::default()
@@ -336,7 +340,7 @@ mod tests {
         assert!(debug.contains("CapturedContext"));
     }
 
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), not(target_os = "macos")))]
     #[test]
     fn capture_context_stub_returns_empty() {
         let ctx = capture_context(false);
@@ -346,7 +350,7 @@ mod tests {
         assert!(ctx.screenshot_base64.is_none());
     }
 
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), not(target_os = "macos")))]
     #[test]
     fn capture_context_stub_ignores_screenshot_flag() {
         let ctx = capture_context(true);

--- a/src/hotkey/mod.rs
+++ b/src/hotkey/mod.rs
@@ -209,11 +209,6 @@ fn run_hook_thread(
 ) -> Result<()> {
     use std::cell::RefCell;
     use windows::Win32::Foundation::{LPARAM, LRESULT, WPARAM};
-    use windows::Win32::UI::Input::KeyboardAndMouse::{
-        VK_BACK, VK_CAPITAL, VK_CONTROL, VK_DELETE, VK_DOWN, VK_END, VK_ESCAPE, VK_HOME,
-        VK_INSERT, VK_LEFT, VK_MENU, VK_NEXT, VK_PRIOR, VK_RETURN, VK_RIGHT, VK_SCROLL,
-        VK_SHIFT, VK_SPACE, VK_TAB, VK_UP,
-    };
     use windows::Win32::UI::WindowsAndMessaging::{
         CallNextHookEx, GetMessageW, SetWindowsHookExW, UnhookWindowsHookEx, HHOOK,
         KBDLLHOOKSTRUCT, MSG, WH_KEYBOARD_LL, WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@ pub mod hotkey;
 pub mod insertion;
 pub mod refinement;
 
+#[cfg(target_os = "macos")]
+pub mod macos;
+
 #[cfg(feature = "audio-capture")]
 pub mod audio;
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,0 +1,307 @@
+//! macOS platform integration.
+//!
+//! The app runs a manual main-thread loop (it is not a winit/eframe app in the
+//! main process), so on macOS we must:
+//!   * become an "accessory" (menu-bar) app so the `tray-icon` status item works
+//!     and no Dock icon is shown;
+//!   * pump the AppKit event queue every tick so status-item menu clicks are
+//!     delivered;
+//!   * request the Accessibility permission required by the global hotkey
+//!     listener (`rdev`) and the text-insertion backend (`enigo`);
+//!   * capture the frontmost app / window / screenshot for refinement context.
+//!
+//! The AppKit lifecycle uses `objc2`; the CoreFoundation / CoreGraphics /
+//! Accessibility bits use direct C FFI (these are extremely stable C ABIs and
+//! avoid the friction of the typed CF wrappers).
+
+use objc2_app_kit::{
+    NSApplication, NSApplicationActivationPolicy, NSEventMask, NSWorkspace,
+};
+use objc2_foundation::{MainThreadMarker, NSDate, NSDefaultRunLoopMode};
+use std::ffi::{c_char, c_long, c_void};
+use tracing::{debug, warn};
+
+use crate::context::CapturedContext;
+
+// ── AppKit lifecycle ────────────────────────────────────────────────────────
+
+/// Initialise NSApplication as an accessory (menu-bar) app with no Dock icon.
+/// Must be called once, on the main thread, before the main loop starts.
+pub fn init_menubar_app() {
+    let Some(mtm) = MainThreadMarker::new() else {
+        warn!("init_menubar_app() called off the main thread; skipping");
+        return;
+    };
+    let app = NSApplication::sharedApplication(mtm);
+    app.setActivationPolicy(NSApplicationActivationPolicy::Accessory);
+    app.finishLaunching();
+    debug!("NSApplication initialised as accessory app");
+}
+
+/// Drain all pending AppKit events. Call once per main-loop tick so the tray
+/// icon's menu works. Non-blocking: returns as soon as the queue is empty.
+pub fn pump_events() {
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    let app = NSApplication::sharedApplication(mtm);
+    // SAFETY: on the main thread; `distantPast` => don't block; the run-loop
+    // mode static and `nextEvent…` are valid AppKit calls.
+    unsafe {
+        let past = NSDate::distantPast();
+        loop {
+            match app.nextEventMatchingMask_untilDate_inMode_dequeue(
+                NSEventMask::Any,
+                Some(&past),
+                NSDefaultRunLoopMode,
+                true,
+            ) {
+                Some(event) => app.sendEvent(&event),
+                None => break,
+            }
+        }
+    }
+}
+
+// ── Accessibility permission ────────────────────────────────────────────────
+
+/// Returns true if the process is already trusted for Accessibility. If it is
+/// not trusted, macOS shows the system prompt directing the user to
+/// System Settings > Privacy & Security > Accessibility (shown once per app).
+pub fn ensure_accessibility_permission() -> bool {
+    #[repr(C)]
+    struct CFCallbacks {
+        _private: [u8; 0],
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        static kCFTypeDictionaryKeyCallBacks: CFCallbacks;
+        static kCFTypeDictionaryValueCallBacks: CFCallbacks;
+        static kCFBooleanTrue: *const c_void;
+        fn CFDictionaryCreate(
+            allocator: *const c_void,
+            keys: *const *const c_void,
+            values: *const *const c_void,
+            num_values: c_long,
+            key_callbacks: *const c_void,
+            value_callbacks: *const c_void,
+        ) -> *const c_void;
+        fn CFRelease(cf: *const c_void);
+    }
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern "C" {
+        static kAXTrustedCheckOptionPrompt: *const c_void; // CFStringRef
+        fn AXIsProcessTrustedWithOptions(options: *const c_void) -> bool;
+    }
+
+    // SAFETY: building a 1-entry CFDictionary { prompt-key: true } and passing
+    // it to the Accessibility API. All pointers are valid CF constants.
+    unsafe {
+        let keys = [kAXTrustedCheckOptionPrompt];
+        let values = [kCFBooleanTrue];
+        let options = CFDictionaryCreate(
+            std::ptr::null(),
+            keys.as_ptr(),
+            values.as_ptr(),
+            1,
+            std::ptr::addr_of!(kCFTypeDictionaryKeyCallBacks) as *const c_void,
+            std::ptr::addr_of!(kCFTypeDictionaryValueCallBacks) as *const c_void,
+        );
+        let trusted = AXIsProcessTrustedWithOptions(options);
+        if !options.is_null() {
+            CFRelease(options);
+        }
+        trusted
+    }
+}
+
+// ── Active-window context capture ───────────────────────────────────────────
+
+/// Capture the frontmost application name, window title, and (optionally) a
+/// screenshot, for use as LLM refinement context.
+pub fn capture_context(include_screenshot: bool) -> CapturedContext {
+    let mut ctx = CapturedContext::default();
+
+    if let Some(name) = frontmost_app_name() {
+        ctx.app_name = name;
+    }
+
+    if let Some((owner, title)) = frontmost_window(&ctx.app_name) {
+        if ctx.app_name.is_empty() {
+            ctx.app_name = owner;
+        }
+        if let Some(title) = title {
+            ctx.window_title = title;
+        }
+    }
+
+    if include_screenshot {
+        ctx.screenshot_base64 = capture_screenshot();
+    }
+
+    debug!(
+        "macOS context: app={:?}, title={:?}, screenshot={}",
+        ctx.app_name,
+        ctx.window_title,
+        ctx.screenshot_base64.is_some()
+    );
+    ctx
+}
+
+fn frontmost_app_name() -> Option<String> {
+    let workspace = NSWorkspace::sharedWorkspace();
+    let app = workspace.frontmostApplication()?;
+    app.localizedName().map(|s| s.to_string())
+}
+
+// CoreFoundation / CoreGraphics C ABI used for window enumeration.
+mod cf {
+    use std::ffi::{c_char, c_long, c_void};
+
+    pub type CFTypeRef = *const c_void;
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        pub fn CFArrayGetCount(arr: CFTypeRef) -> c_long;
+        pub fn CFArrayGetValueAtIndex(arr: CFTypeRef, idx: c_long) -> CFTypeRef;
+        pub fn CFDictionaryGetValue(dict: CFTypeRef, key: CFTypeRef) -> CFTypeRef;
+        pub fn CFStringGetCStringPtr(s: CFTypeRef, encoding: u32) -> *const c_char;
+        pub fn CFStringGetCString(
+            s: CFTypeRef,
+            buffer: *mut c_char,
+            size: c_long,
+            encoding: u32,
+        ) -> bool;
+        pub fn CFStringGetLength(s: CFTypeRef) -> c_long;
+        pub fn CFNumberGetValue(num: CFTypeRef, the_type: c_long, value: *mut c_void) -> bool;
+        pub fn CFRelease(cf: CFTypeRef);
+    }
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        pub fn CGWindowListCopyWindowInfo(option: u32, relative_to_window: u32) -> CFTypeRef;
+        pub static kCGWindowOwnerName: CFTypeRef; // CFStringRef
+        pub static kCGWindowName: CFTypeRef; // CFStringRef
+        pub static kCGWindowLayer: CFTypeRef; // CFStringRef
+    }
+
+    pub const UTF8: u32 = 0x0800_0100; // kCFStringEncodingUTF8
+    pub const SINT32: c_long = 3; // kCFNumberSInt32Type
+    pub const ON_SCREEN_ONLY: u32 = 1 << 0;
+    pub const EXCLUDE_DESKTOP: u32 = 1 << 4;
+    pub const NULL_WINDOW_ID: u32 = 0;
+}
+
+/// Convert a CFStringRef into a Rust String.
+unsafe fn cfstring_to_string(s: cf::CFTypeRef) -> Option<String> {
+    if s.is_null() {
+        return None;
+    }
+    // Fast path: a directly-usable UTF-8 pointer (not always available).
+    let ptr = cf::CFStringGetCStringPtr(s, cf::UTF8);
+    if !ptr.is_null() {
+        return Some(std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned());
+    }
+    let len = cf::CFStringGetLength(s);
+    if len <= 0 {
+        return Some(String::new());
+    }
+    // Worst case for UTF-8 is 4 bytes per UTF-16 code unit, plus NUL.
+    let capacity = (len as usize) * 4 + 1;
+    let mut buf = vec![0 as c_char; capacity];
+    if cf::CFStringGetCString(s, buf.as_mut_ptr(), capacity as c_long, cf::UTF8) {
+        Some(
+            std::ffi::CStr::from_ptr(buf.as_ptr())
+                .to_string_lossy()
+                .into_owned(),
+        )
+    } else {
+        None
+    }
+}
+
+/// Find the frontmost ordinary (layer 0) window. Prefers a window owned by
+/// `preferred_owner` if given; otherwise returns the first on-screen normal
+/// window. Returns (owner_name, optional_title).
+fn frontmost_window(preferred_owner: &str) -> Option<(String, Option<String>)> {
+    // SAFETY: standard CoreGraphics window-list enumeration. The returned array
+    // is owned by us (Copy) and released at the end.
+    unsafe {
+        let list = cf::CGWindowListCopyWindowInfo(
+            cf::ON_SCREEN_ONLY | cf::EXCLUDE_DESKTOP,
+            cf::NULL_WINDOW_ID,
+        );
+        if list.is_null() {
+            return None;
+        }
+
+        let count = cf::CFArrayGetCount(list);
+        let mut first_normal: Option<(String, Option<String>)> = None;
+        let mut matched: Option<(String, Option<String>)> = None;
+
+        for i in 0..count {
+            let dict = cf::CFArrayGetValueAtIndex(list, i);
+            if dict.is_null() {
+                continue;
+            }
+
+            // Only consider layer 0 (ordinary application windows).
+            let layer_val = cf::CFDictionaryGetValue(dict, cf::kCGWindowLayer);
+            let mut layer: i32 = -1;
+            if !layer_val.is_null() {
+                cf::CFNumberGetValue(
+                    layer_val,
+                    cf::SINT32,
+                    &mut layer as *mut i32 as *mut c_void,
+                );
+            }
+            if layer != 0 {
+                continue;
+            }
+
+            let owner = cfstring_to_string(cf::CFDictionaryGetValue(dict, cf::kCGWindowOwnerName))
+                .unwrap_or_default();
+            // kCGWindowName requires Screen Recording permission; may be absent.
+            let title = cfstring_to_string(cf::CFDictionaryGetValue(dict, cf::kCGWindowName))
+                .filter(|t| !t.is_empty());
+
+            if first_normal.is_none() {
+                first_normal = Some((owner.clone(), title.clone()));
+            }
+            if !preferred_owner.is_empty() && owner == preferred_owner {
+                matched = Some((owner, title));
+                break;
+            }
+        }
+
+        cf::CFRelease(list);
+        matched.or(first_normal)
+    }
+}
+
+/// Capture the screen to a PNG and return it base64-encoded.
+/// Uses the `screencapture` CLI (requires Screen Recording permission; if not
+/// granted the capture simply returns desktop wallpaper or nothing).
+fn capture_screenshot() -> Option<String> {
+    use base64::Engine;
+
+    let tmp = std::env::temp_dir().join(format!("duper-disper-shot-{}.png", std::process::id()));
+    let status = std::process::Command::new("screencapture")
+        .arg("-x") // no shutter sound
+        .arg("-t")
+        .arg("png")
+        .arg(&tmp)
+        .status()
+        .ok()?;
+    if !status.success() {
+        return None;
+    }
+    let bytes = std::fs::read(&tmp).ok()?;
+    let _ = std::fs::remove_file(&tmp);
+    if bytes.is_empty() {
+        return None;
+    }
+    Some(base64::engine::general_purpose::STANDARD.encode(bytes))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -450,7 +450,8 @@ fn play_feedback(start: bool) {
     }
     #[cfg(windows)]
     {
-        use windows::Win32::UI::WindowsAndMessaging::{MessageBeep, MB_ICONASTERISK, MB_OK};
+        use windows::Win32::System::Diagnostics::Debug::MessageBeep;
+        use windows::Win32::UI::WindowsAndMessaging::{MB_ICONASTERISK, MB_OK};
         let kind = if start { MB_OK } else { MB_ICONASTERISK };
         unsafe {
             let _ = MessageBeep(kind);

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,11 @@ fn main() -> Result<()> {
     // Ensure only one instance of the main app runs at a time
     let _instance_lock = acquire_single_instance_lock()?;
 
+    // Detect first run (no config file yet) before load() creates the default.
+    let first_run = !AppConfig::config_path()
+        .map(|p| p.exists())
+        .unwrap_or(false);
+
     // Load config early to check developer_mode for log level
     let config = AppConfig::load()?;
 
@@ -65,6 +70,21 @@ fn main() -> Result<()> {
 
     info!("Duper Disper v{} starting", env!("CARGO_PKG_VERSION"));
     info!("Config loaded: stt={:?}, hotkey={}, developer_mode={}", config.stt_backend, config.hotkey, config.developer_mode);
+
+    // macOS: become a menu-bar (accessory) app so the tray icon and its menu
+    // work without a Dock icon, and prompt for the Accessibility permission
+    // required for global hotkeys (rdev) and text insertion (enigo).
+    #[cfg(target_os = "macos")]
+    {
+        duper_disper::macos::init_menubar_app();
+        if !duper_disper::macos::ensure_accessibility_permission() {
+            warn!(
+                "Accessibility permission not granted yet. The hotkey and text \
+                 insertion will not work until it is enabled in System Settings \
+                 > Privacy & Security > Accessibility."
+            );
+        }
+    }
 
     // Initialize transcriber based on configured backend
     let transcriber = match config.stt_backend {
@@ -110,7 +130,7 @@ fn main() -> Result<()> {
     info!("Registered hotkey: {}", config.hotkey);
 
     // Set up system tray
-    let tray = SystemTray::new()?;
+    let mut tray = SystemTray::new()?;
 
     // Create tokio runtime for async operations (LLM calls)
     let rt = tokio::runtime::Builder::new_multi_thread()
@@ -124,12 +144,10 @@ fn main() -> Result<()> {
 
     start_single_instance_ipc(&_instance_lock, settings_child.clone());
 
-    #[cfg(target_os = "macos")]
-    settings::open_settings_window(&settings_child);
-
-    // If launched with --show-settings, open settings window on startup
-    // (unlike --settings, the main app keeps running)
-    if std::env::args().any(|a| a == "--show-settings") {
+    // Open the settings window automatically on first run (onboarding) or when
+    // explicitly requested via --show-settings. We deliberately do NOT reopen it
+    // on every launch — the app lives in the tray/menu bar.
+    if first_run || std::env::args().any(|a| a == "--show-settings") {
         settings::open_settings_window(&settings_child);
     }
 
@@ -149,12 +167,18 @@ fn main() -> Result<()> {
                 recording_buffer.start();
                 overlay.show_recording();
                 tray.set_recording(true);
+                if config.sound_feedback {
+                    play_feedback(true);
+                }
                 info!("Recording started");
             } else if !pressed && is_recording.load(Ordering::SeqCst) {
                 // Stop recording
                 is_recording.store(false, Ordering::SeqCst);
                 recording_buffer.stop();
                 tray.set_recording(false);
+                if config.sound_feedback {
+                    play_feedback(false);
+                }
                 info!("Recording stopped");
 
                 // Process the recording
@@ -399,7 +423,41 @@ fn pump_messages() {
     }
 }
 
-#[cfg(not(windows))]
+/// Drain pending AppKit events so the tray icon and its menu work on macOS.
+/// The status item delivers menu clicks via the AppKit run loop, which we pump
+/// once per main-loop tick.
+#[cfg(target_os = "macos")]
 fn pump_messages() {
-    // No-op on non-Windows platforms
+    duper_disper::macos::pump_events();
+}
+
+#[cfg(all(not(windows), not(target_os = "macos")))]
+fn pump_messages() {
+    // No-op on other platforms
+}
+
+/// Play a short sound cue when recording starts/stops.
+fn play_feedback(start: bool) {
+    #[cfg(target_os = "macos")]
+    {
+        // Built-in system sounds via afplay (spawned, non-blocking).
+        let sound = if start {
+            "/System/Library/Sounds/Tink.aiff"
+        } else {
+            "/System/Library/Sounds/Pop.aiff"
+        };
+        let _ = std::process::Command::new("afplay").arg(sound).spawn();
+    }
+    #[cfg(windows)]
+    {
+        use windows::Win32::UI::WindowsAndMessaging::{MessageBeep, MB_ICONASTERISK, MB_OK};
+        let kind = if start { MB_OK } else { MB_ICONASTERISK };
+        unsafe {
+            let _ = MessageBeep(kind);
+        }
+    }
+    #[cfg(all(not(windows), not(target_os = "macos")))]
+    {
+        let _ = start;
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -446,7 +446,11 @@ fn play_feedback(start: bool) {
         } else {
             "/System/Library/Sounds/Pop.aiff"
         };
-        let _ = std::process::Command::new("afplay").arg(sound).spawn();
+        if let Ok(mut child) = std::process::Command::new("afplay").arg(sound).spawn() {
+            std::thread::spawn(move || {
+                let _ = child.wait();
+            });
+        }
     }
     #[cfg(windows)]
     {

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -24,6 +24,18 @@ impl OverlayState {
             Self::Hidden => "",
         }
     }
+
+    /// Reconstruct the state from the `u8` stored in the shared atomic.
+    /// Used by the Windows WNDPROC to read the current render state.
+    #[cfg(windows)]
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Recording,
+            2 => Self::Transcribing,
+            3 => Self::Refining,
+            _ => Self::Hidden,
+        }
+    }
 }
 
 // ── Windows implementation ──────────────────────────────────────────────────

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -56,6 +56,7 @@ pub fn run_settings_window() -> Result<(), eframe::Error> {
         viewport: egui::ViewportBuilder::default()
             .with_inner_size([520.0, 580.0])
             .with_min_inner_size([420.0, 400.0])
+            .with_active(true)
             .with_title("Duper Disper"),
         #[cfg(target_os = "windows")]
         event_loop_builder: Some(Box::new(|builder| {
@@ -72,6 +73,28 @@ pub fn run_settings_window() -> Result<(), eframe::Error> {
             Ok(Box::new(app))
         }),
     )
+}
+
+/// Reveal a file in the platform's file manager (Explorer/Finder/file browser).
+fn reveal_in_file_manager(path: &std::path::Path) {
+    #[cfg(target_os = "macos")]
+    let result = std::process::Command::new("open").arg("-R").arg(path).spawn();
+
+    #[cfg(windows)]
+    let result = std::process::Command::new("explorer")
+        .arg(format!("/select,{}", path.display()))
+        .spawn();
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let result = {
+        // xdg-open can't select a file, so open the containing directory.
+        let target = path.parent().unwrap_or(path);
+        std::process::Command::new("xdg-open").arg(target).spawn()
+    };
+
+    if let Err(e) = result {
+        error!("Failed to reveal config file: {}", e);
+    }
 }
 
 fn configure_style(ctx: &egui::Context) {
@@ -236,10 +259,7 @@ impl SettingsApp {
 
                 if let Ok(config_path) = AppConfig::config_path() {
                     if ui.button("Show Config File").clicked() {
-                        let _ = std::process::Command::new("open")
-                            .arg("-R")
-                            .arg(config_path)
-                            .spawn();
+                        reveal_in_file_manager(&config_path);
                     }
                 }
             });
@@ -337,7 +357,7 @@ impl SettingsApp {
                 ui.checkbox(&mut self.config.show_overlay, "");
                 ui.end_row();
 
-                #[cfg(windows)]
+                #[cfg(any(windows, target_os = "macos"))]
                 {
                     ui.label("Auto-start on login:");
                     ui.checkbox(&mut self.config.auto_start, "");

--- a/src/ui/tray.rs
+++ b/src/ui/tray.rs
@@ -9,10 +9,11 @@ pub enum TrayCommand {
 }
 
 pub struct SystemTray {
-    _tray: TrayIcon,
+    tray: TrayIcon,
     settings_id: MenuItem,
     toggle_refinement_id: MenuItem,
     quit_id: MenuItem,
+    recording: bool,
 }
 
 impl SystemTray {
@@ -27,22 +28,20 @@ impl SystemTray {
         menu.append(&toggle_item)?;
         menu.append(&quit_item)?;
 
-        // Create a simple icon (red circle to indicate "recording ready")
-        let icon = create_default_icon();
-
         let tray = TrayIconBuilder::new()
             .with_menu(Box::new(menu))
             .with_tooltip("Duper Disper - Push to Talk")
-            .with_icon(icon)
+            .with_icon(create_icon(false))
             .build()?;
 
         info!("System tray icon created");
 
         Ok(Self {
-            _tray: tray,
+            tray,
             settings_id: settings_item,
             toggle_refinement_id: toggle_item,
             quit_id: quit_item,
+            recording: false,
         })
     }
 
@@ -62,18 +61,38 @@ impl SystemTray {
         None
     }
 
-    pub fn set_recording(&self, recording: bool) {
-        // Could update icon color here (green = recording, red = idle)
-        let _ = recording;
+    /// Reflect the recording state in the tray icon and tooltip.
+    /// Red dot = recording, blue dot = idle. This is the primary visual
+    /// feedback on platforms without a floating overlay (macOS/Linux).
+    pub fn set_recording(&mut self, recording: bool) {
+        if recording == self.recording {
+            return;
+        }
+        self.recording = recording;
+        if let Err(e) = self.tray.set_icon(Some(create_icon(recording))) {
+            tracing::warn!("Failed to update tray icon: {}", e);
+        }
+        let tooltip = if recording {
+            "Duper Disper - Recording..."
+        } else {
+            "Duper Disper - Push to Talk"
+        };
+        let _ = self.tray.set_tooltip(Some(tooltip));
     }
 }
 
-fn create_default_icon() -> tray_icon::Icon {
-    // Create a simple 32x32 RGBA icon (blue circle)
+/// Build a 32x32 RGBA circle icon. Red when recording, blue when idle.
+fn create_icon(recording: bool) -> tray_icon::Icon {
     let size = 32;
     let mut rgba = vec![0u8; size * size * 4];
     let center = size as f32 / 2.0;
     let radius = center - 2.0;
+
+    let (r, g, b) = if recording {
+        (229u8, 53u8, 53u8) // #E53535 red
+    } else {
+        (66u8, 133u8, 244u8) // #4285F4 blue
+    };
 
     for y in 0..size {
         for x in 0..size {
@@ -83,13 +102,16 @@ fn create_default_icon() -> tray_icon::Icon {
             let idx = (y * size + x) * 4;
 
             if dist <= radius {
-                rgba[idx] = 66;      // R
-                rgba[idx + 1] = 133; // G
-                rgba[idx + 2] = 244; // B
-                rgba[idx + 3] = 255; // A
+                // Anti-alias the edge for a smoother look.
+                let alpha = ((radius - dist).clamp(0.0, 1.0) * 255.0) as u8;
+                rgba[idx] = r;
+                rgba[idx + 1] = g;
+                rgba[idx + 2] = b;
+                rgba[idx + 3] = if dist <= radius - 1.0 { 255 } else { alpha };
             }
         }
     }
 
-    tray_icon::Icon::from_rgba(rgba, size as u32, size as u32).unwrap()
+    tray_icon::Icon::from_rgba(rgba, size as u32, size as u32)
+        .expect("valid RGBA tray icon")
 }


### PR DESCRIPTION
## Summary

macOS support was only half-wired — most OS integration was `#[cfg(windows)]`-only, so on a Mac the tray menu never worked, refinement lost all context, and the app would be **killed** the moment it touched the microphone. This makes macOS a first-class path and fixes a few cross-platform bugs along the way.

## Critical macOS fixes (app was broken/crashing)
- **Mic permission / agent app** — CI now injects `NSMicrophoneUsageDescription` (its absence is what terminates the app on mic access), `LSUIElement` (no Dock icon), and `NSAppleEventsUsageDescription` into the bundled `Info.plist` via PlistBuddy after `cargo bundle`.
- **Menu-bar event loop** — `tray-icon`'s status item + menu need a live `NSApplication`; the old `pump_messages()` was a no-op on macOS. New `src/macos.rs` initialises NSApp as an accessory app and drains the AppKit event queue each tick.
- **Accessibility permission** — `rdev` (hotkey) and `enigo` (paste/type) both require it; the app now prompts on startup.

## High-value UX
- macOS **context capture**: frontmost app (NSWorkspace), window title (CGWindowList), optional screenshot (`screencapture`) — was a no-op stub.
- **Tray icon turns red while recording** + tooltip update (feedback replacement for the Windows-only overlay), and **sound feedback** (config toggle existed but was wired to nothing) — `afplay` on macOS, `MessageBeep` on Windows.
- Settings window auto-opens **only on first run**, not every launch; **auto-start on login** via LaunchAgent (+ checkbox); cross-platform "Show config file".

## Cross-platform bug fixes
- `resample()` no longer drops the only sample of a very short clip and guards against empty input (fixes a failing unit test).
- `cargo build --no-default-features` no longer fails — the binary is gated on its required features so only the library builds in that config.

## Implementation notes
`src/macos.rs` uses `objc2`/`objc2-app-kit` for the AppKit lifecycle (verified against the 0.3 API) and direct, stable C FFI for CoreFoundation / CoreGraphics / Accessibility (avoids the fiddly typed-CFArray surface).

## Verification
- ✅ Full default-feature build + **106 unit tests pass** (Linux).
- ✅ `src/macos.rs` type-checks against `x86_64-apple-darwin` (confirms the `objc2` usage).
- ⏳ Link + runtime on real macOS is what the macOS CI job here confirms.

https://claude.ai/code/session_01RtgeimgkSuHmtx4NaCaq8b

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtgeimgkSuHmtx4NaCaq8b)_