### PR TITLE
CI: auto-version and auto-release from GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,50 +6,79 @@ on:
   pull_request:
     branches: [main, master]
   workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump for the release (main/master only)'
+        type: choice
+        options: [patch, minor, major]
+        default: patch
 
 env:
   CARGO_TERM_COLOR: always
 
+# Releases are owned by this workflow: git tags are the single source of truth
+# for the version. On every push to main/master the version is auto-bumped from
+# the latest v* tag (patch by default; choose minor/major via "Run workflow"),
+# the build is stamped with that version, and a GitHub Release + tag are created.
+# The version in Cargo.toml is only a local/dev baseline — CI overrides it.
 jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
-      skip_release: ${{ steps.check.outputs.SKIP }}
+      is_release: ${{ steps.version.outputs.IS_RELEASE }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Get version
+      - name: Compute version
         id: version
         shell: bash
         run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          git fetch --tags --force >/dev/null 2>&1 || true
 
-      - name: Check if release needed
-        id: check
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
-        shell: bash
-        run: |
-          VERSION="v${{ steps.version.outputs.VERSION }}"
-          if git rev-parse "$VERSION" >/dev/null 2>&1; then
-            echo "SKIP=true" >> "$GITHUB_OUTPUT"
-            echo "Tag $VERSION already exists, skipping release"
+          # Latest existing release version (strip leading "v"); default 0.0.0.
+          LATEST=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sed 's/^v//' | sort -V | tail -n1)
+          [ -z "$LATEST" ] && LATEST="0.0.0"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST"
+
+          IS_RELEASE=false
+          if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            IS_RELEASE=true
+            BUMP="${{ github.event.inputs.bump }}"
+            BUMP="${BUMP:-patch}"
+            case "$BUMP" in
+              major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+              minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+              *)     PATCH=$((PATCH + 1)) ;;
+            esac
+            VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            # Never collide with an existing tag (e.g. re-runs): keep bumping patch.
+            while git rev-parse "v${VERSION}" >/dev/null 2>&1; do
+              PATCH=$((PATCH + 1))
+              VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            done
           else
-            echo "SKIP=false" >> "$GITHUB_OUTPUT"
-            echo "Will create release $VERSION"
+            # Non-release builds (PRs, claude/** branches) just label artifacts.
+            VERSION="${MAJOR}.${MINOR}.${PATCH}"
           fi
+
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "IS_RELEASE=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION (release=$IS_RELEASE, latest tag was v$LATEST)"
 
   build-windows:
     runs-on: windows-latest
     needs: prepare
     steps:
       - uses: actions/checkout@v4
+
+      - name: Stamp version
+        shell: bash
+        run: |
+          sed -E "s/^version = \"[^\"]*\"/version = \"${{ needs.prepare.outputs.version }}\"/" Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          grep -m1 '^version' Cargo.toml
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -94,6 +123,12 @@ jobs:
     needs: prepare
     steps:
       - uses: actions/checkout@v4
+
+      - name: Stamp version
+        shell: bash
+        run: |
+          sed -E "s/^version = \"[^\"]*\"/version = \"${{ needs.prepare.outputs.version }}\"/" Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+          grep -m1 '^version' Cargo.toml
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -154,9 +189,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [prepare, build-windows, build-macos]
-    if: |
-      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') &&
-      needs.prepare.outputs.skip_release == 'false'
+    if: needs.prepare.outputs.is_release == 'true'
     permissions:
       contents: write
     steps:
@@ -176,8 +209,11 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.prepare.outputs.version }}
+          target_commitish: ${{ github.sha }}
+          name: v${{ needs.prepare.outputs.version }}
           files: release-artifacts/*
           generate_release_notes: true
           draft: false
+          make_latest: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Serialize release-producing runs per ref so two pushes to main can't race in
+# `prepare`/`release` and compute the same version or clobber each other's
+# release. cancel-in-progress is false so an in-flight release is never killed.
+concurrency:
+  group: build-release-${{ github.ref }}
+  cancel-in-progress: false
+
 # Releases are owned by this workflow: git tags are the single source of truth
 # for the version. On every push to main/master the version is auto-bumped from
 # the latest v* tag (patch by default; choose minor/major via "Run workflow"),
@@ -43,25 +50,36 @@ jobs:
           [ -z "$LATEST" ] && LATEST="0.0.0"
           IFS='.' read -r MAJOR MINOR PATCH <<< "$LATEST"
 
-          IS_RELEASE=false
-          if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            IS_RELEASE=true
-            BUMP="${{ github.event.inputs.bump }}"
-            BUMP="${BUMP:-patch}"
-            case "$BUMP" in
+          # Apply a bump level to MAJOR/MINOR/PATCH.
+          bump() {
+            case "$1" in
               major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
               minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
               *)     PATCH=$((PATCH + 1)) ;;
             esac
+          }
+
+          if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            IS_RELEASE=true
+            BUMP="${{ github.event.inputs.bump }}"
+            BUMP="${BUMP:-patch}"
+            bump "$BUMP"
             VERSION="${MAJOR}.${MINOR}.${PATCH}"
-            # Never collide with an existing tag (e.g. re-runs): keep bumping patch.
+            # On collision (e.g. a re-run after the tag was created) keep bumping
+            # the SAME component the user asked for, so a repeated major stays a
+            # major (3.0.0, 4.0.0, ...) rather than degrading to a patch.
             while git rev-parse "v${VERSION}" >/dev/null 2>&1; do
-              PATCH=$((PATCH + 1))
+              bump "$BUMP"
               VERSION="${MAJOR}.${MINOR}.${PATCH}"
             done
           else
-            # Non-release builds (PRs, claude/** branches) just label artifacts.
-            VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            # Non-release builds (PRs, claude/** branches): mark as a pre-release
+            # of the next patch, disambiguated by short SHA, so artifacts are
+            # never mistaken for a published release. The "g" prefix keeps the
+            # identifier valid semver even if the SHA is all digits.
+            IS_RELEASE=false
+            SHORT=$(git rev-parse --short=7 HEAD)
+            VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-dev.g${SHORT}"
           fi
 
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why

No fresh release appeared after the macOS PR merged because releases were gated on the `Cargo.toml` version: the release job **skipped itself whenever a tag for the current version already existed** (`v0.2.0` exists, and `Cargo.toml` is still `0.2.0`). So a merge with no manual version bump = no release.

## What

Make the workflow the **single source of truth** for releases (git tags drive the version):

- **`prepare`** computes the next version from the latest `v*` tag — **patch bump by default**, or `minor`/`major` via the `workflow_dispatch` **"bump"** input — and guards against tag collisions.
- **Each build job stamps** that version into `Cargo.toml` before building, so the binaries, the macOS `.app` bundle, and the artifact filenames all reflect it.
- **`release`** now runs on every push to `main`/`master` and creates the tag + GitHub Release (`softprops/action-gh-release`, `make_latest: true`).

## Effect

Merging this PR auto-publishes **v0.2.1** (latest tag `v0.2.0` → patch bump) with the Windows installer/portable zip and the macOS app zip. Every future merge to `main` auto-publishes the next patch release; tags are authoritative and `Cargo.toml`'s version is just a local/dev baseline. To cut a minor/major instead, use **Actions → Run workflow → bump**.

Validated locally: YAML parses; the bump logic resolves `v0.2.0 → 0.2.1`; the stamp `sed` edits only the `[package]` version line (dependency versions untouched).

https://claude.ai/code/session_01RtgeimgkSuHmtx4NaCaq8b

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtgeimgkSuHmtx4NaCaq8b)_