### PR TITLE
CI: ship macOS release as a DMG instead of a ZIP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,13 +190,19 @@ jobs:
           echo "----- Final Info.plist -----"
           /usr/libexec/PlistBuddy -c "Print" "${PLIST}"
 
-      - name: Package app bundle
+      - name: Create DMG
         shell: bash
         run: |
-          mkdir -p installer/output
-          ditto -c -k --sequesterRsrc --keepParent \
-            "target/release/bundle/osx/Duper Disper.app" \
-            "installer/output/duper-disper-${{ needs.prepare.outputs.version }}-macos-app.zip"
+          mkdir -p installer/output dmg-stage
+          cp -R "target/release/bundle/osx/Duper Disper.app" dmg-stage/
+          # Drag-to-install: a symlink so the DMG window shows /Applications.
+          ln -s /Applications dmg-stage/Applications
+          hdiutil create \
+            -volname "Duper Disper" \
+            -srcfolder dmg-stage \
+            -fs HFS+ \
+            -format UDZO -ov \
+            "installer/output/duper-disper-${{ needs.prepare.outputs.version }}-macos.dmg"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Download the latest release from the [Releases page](https://github.com/sgstq/du
 - **Portable** — `duper-disper-x.x.x-portable.zip` — standalone executable, no installation needed
 
 **macOS**
-- **App bundle** — `duper-disper-x.x.x-macos-app.zip` — unzip and drag `Duper Disper.app` to `/Applications`
+- **Disk image** — `duper-disper-x.x.x-macos.dmg` — open it and drag `Duper Disper.app` into the `Applications` folder
 
 On macOS the app runs as a menu-bar (status-bar) app with no Dock icon. On first
 launch it will prompt for **Accessibility** permission (needed to detect the


### PR DESCRIPTION
## What

Ship the macOS release artifact as a **`.dmg`** instead of a `.zip`.

The macOS build now packages with `hdiutil` into `duper-disper-<version>-macos.dmg`, containing `Duper Disper.app` plus an `/Applications` symlink so users get the standard drag-to-install window. The old `ditto` zip step is removed. README download line updated accordingly.

## Effect

Merging this auto-publishes the next release (**v0.2.2**) whose macOS asset is `duper-disper-<version>-macos.dmg` (Windows installer/portable unchanged).

Validated: workflow YAML parses.

https://claude.ai/code/session_01RtgeimgkSuHmtx4NaCaq8b

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtgeimgkSuHmtx4NaCaq8b)_